### PR TITLE
updated where applicant id is being pulled from state

### DIFF
--- a/src/components/applicant-profile/ApplicantProfile.js
+++ b/src/components/applicant-profile/ApplicantProfile.js
@@ -18,7 +18,7 @@ export default function ApplicantProfile() {
   const userType = useSelector(state => state.login.usertype);
   const isEditing = useSelector(state => state.profileInfo.isEditing);
   const applicantProfileId = useSelector(
-    state => state.profileInfo.profileDetails.applicant_id
+    state => state.login.userId
   );
   const applicantDetails = useSelector(
     state => state.profileInfo.profileDetails


### PR DESCRIPTION
# Description
Fixed app so that applicant profile renders again.

Fixes # (issue)
Applicant ID being pulled from profile details in state which didn't work.